### PR TITLE
[DOCUMENTATION] Update readme to clarify how to use image uri with base64

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ class YourComponent extends Component {
           detectionCountBeforeCapture={5}
           detectionRefreshRateInMS={50}
         />
-        <Image source={{ uri: `data:image/jpeg;base64,${this.state.image}`}} resizeMode="contain" />
+        <Image source={{ uri: `${this.state.image}`}} resizeMode="contain" />
+        // NOTE: You have to describe the data type of the uri when using a base64 image e.g.
+        // <Image source={{ uri: `data:image/jpeg;base64${this.state.image}`}} resizeMode="contain" />
       </View>
     );
   }


### PR DESCRIPTION
Small update to the documentation re: how to use the `uri` param on the React Native `Image` component.

